### PR TITLE
Get vignette to build

### DIFF
--- a/R/loadLm.R
+++ b/R/loadLm.R
@@ -323,8 +323,6 @@ predictSolute.loadLm <- function(
                              format = flux.or.conc, dates = getCol(load.model@metadata, newdata, "date"))
     if(interval != "none" || se.fit || se.pred) {
       warning("Uncertainty for aggregated predictions is currently unavailable for loadLm models")
-    } else {
-      preds <- preds %>% dplyr::select(-SE, -CI_lower, -CI_upper)
     }
   }
 

--- a/vignettes/intro_to_loadflex.Rmd
+++ b/vignettes/intro_to_loadflex.Rmd
@@ -75,7 +75,7 @@ no3_lr <- loadReg2(loadReg(NO3 ~ model(9), data=regdat,
   flow.units="cfs", conc.units="mg/L", load.units="kg",
   station='Lamprey River, NH'))
 no3_lc <- loadComp(reg.model=no3_lr, interp.format="conc", 
-  interp.data=intdat)
+  interp.data=intdat, store = "uncertainty")
 ```
 
 You can inspect these models in a variety of model-specific ways. Here are some commands to try (we won't print them here because the output can be lengthy):


### PR DESCRIPTION
See #241 

The changes in this PR solve errors getting the vignette to build. 

The change to the vignette file is straightforward and I'm confident it's correct. I'm less sure about the change to `R/loadLm.R`. It's needed to build but I'm not sure if it indicates something else wrong earlier in the processing chain (elsewhere in the code). 

Also, the fitted diagnostics for the lm model are fairly poor. Not sure if this is expected (notice the R^2 value):

![Screenshot from 2020-09-17 09-50-25](https://user-images.githubusercontent.com/7844578/93480727-c24b8480-f8cb-11ea-9893-7706ca76cf6d.png)
